### PR TITLE
use s3pository over nodejs.org

### DIFF
--- a/lib/language_pack/helpers/node_installer.rb
+++ b/lib/language_pack/helpers/node_installer.rb
@@ -5,7 +5,7 @@ class LanguagePack::NodeInstaller
   LEGACY_NODE_VERSION = "0.4.7"
   LEGACY_BINARY_PATH = "node-#{LEGACY_NODE_VERSION}"
 
-  NODEJS_BASE_URL     = "https://nodejs.org/dist/v#{MODERN_NODE_VERSION}/"
+  NODEJS_BASE_URL     = "http://s3pository.heroku.com/node/v#{MODERN_NODE_VERSION}/"
 
   def initialize(stack)
     @fetchers = {


### PR DESCRIPTION
cherry-picking this commit
https://github.com/heroku/heroku-buildpack-ruby/commit/e9774450b6a3b906df21040dd6cf3b6bdfd57c2f

nodejs.org is very unstable.

@nickelser @ankane 