### PR TITLE
Use 1.10.6 (what is being used right now). And specify version in com…

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -13,7 +13,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.6"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "1.9.1"
+  BUNDLER_VERSION      = "1.10.6"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   JVM_BASE_URL         = "http://heroku-jdk.s3.amazonaws.com"
   LATEST_JVM_VERSION   = "openjdk7-latest"
@@ -482,8 +482,7 @@ WARNING
       log("bundle") do
         bundle_without = env("BUNDLE_WITHOUT") || "development:test"
         bundle_bin     = "bundle"
-        #bundle_command = "#{bundle_bin} _#{BUNDLER_VERSION}_ install --without #{bundle_without} --path vendor/bundle --binstubs #{bundler_binstubs_path}"
-        bundle_command = "#{bundle_bin} install --without #{bundle_without} --path vendor/bundle --binstubs #{bundler_binstubs_path}"
+        bundle_command = "#{bundle_bin} _#{BUNDLER_VERSION}_ install --without #{bundle_without} --path vendor/bundle --binstubs #{bundler_binstubs_path}"
         bundle_command << " -j4"
 
         if bundler.windows_gemfile_lock?


### PR DESCRIPTION
…mand.

@kwent @nickelser 

We are currently using 1.10.6 (because version is not specified and the host defaults to 1.10.6).

@righi We want to test 1.11.2. But first I want to change the version specification back so we can test in a branch. Does this look ok to you?