### PR TITLE
bundler-1.11.2

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -13,7 +13,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.6"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "1.9.1"
+  BUNDLER_VERSION      = "1.11.2"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   JVM_BASE_URL         = "http://heroku-jdk.s3.amazonaws.com"
   LATEST_JVM_VERSION   = "openjdk7-latest"


### PR DESCRIPTION
Using: https://github.com/kwent/heroku-bundler-1.11.2

```
19:13:41 -----> Using Ruby version: ruby-2.3.0
19:13:41 -----> Installing dependencies using 1.11.2
```

cc @cxmcc @nickelser @solidsnack @gmccreight 