### PR TITLE
Revert "Merge pull request #8 from instacart/bundler-1.12.0"

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -14,7 +14,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.6"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "1.12.0"
+  BUNDLER_VERSION      = "1.11.2"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"
   NODE_BP_PATH         = "vendor/node/bin"


### PR DESCRIPTION
This reverts commit e5eb55fa00d03b6760cf0f6867c78b75d37abdc1, reversing
changes made to d506f1dc9691699239e74e60f4ea8212b63e7912.

Using bundler 1.12.0 was causing build failures if you bundled locally with 1.12, as bundler would try to install a patch-level version of ruby, which didn't exist in the s3 bucket. Let's wait until heroku upgrades the buildpack to use 1.12 instead.